### PR TITLE
記事詳細表示機能実装（ADR学習：パラメータ処理とエラーハンドリング）

### DIFF
--- a/app/Actions/Article/ShowArticleAction.php
+++ b/app/Actions/Article/ShowArticleAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Actions\Article;
+
+use App\Responders\Web\ArticleWebResponder;
+use App\UseCases\Article\ShowArticleUseCase;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+/**
+ * 記事詳細表示Action
+ *
+ * ADRパターンのエントリポイント:
+ * - HTTPリクエストとパラメータの受け取り
+ * - パラメータの検証と抽出
+ * - UseCaseへの委譲
+ * - Responderでのレスポンス生成
+ */
+final readonly class ShowArticleAction
+{
+    public function __construct(
+        private ShowArticleUseCase $useCase,
+        private ArticleWebResponder $responder,
+    ) {}
+
+    /**
+     * 記事詳細表示のメイン処理
+     *
+     * @param  Request  $request  HTTPリクエスト
+     * @param  int  $id  記事ID
+     */
+    public function __invoke(Request $request, int $id): View
+    {
+        // パラメータバリデーション（正の整数であることを確認）
+        if ($id <= 0) {
+            abort(404, '記事が見つかりません');
+        }
+
+        // UseCaseでビジネスロジック実行
+        $article = $this->useCase->execute($id);
+
+        // Responderでレスポンス整形
+        return $this->responder->show($article);
+    }
+} 

--- a/app/Actions/Article/ShowArticleAction.php
+++ b/app/Actions/Article/ShowArticleAction.php
@@ -42,4 +42,4 @@ final readonly class ShowArticleAction
         // Responderでレスポンス整形
         return $this->responder->show($article);
     }
-} 
+}

--- a/app/Responders/Web/ArticleWebResponder.php
+++ b/app/Responders/Web/ArticleWebResponder.php
@@ -2,6 +2,7 @@
 
 namespace App\Responders\Web;
 
+use App\Models\Article;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 
@@ -28,6 +29,19 @@ final readonly class ArticleWebResponder
             'currentPage' => $articles->currentPage(),
             'lastPage' => $articles->lastPage(),
             'hasPages' => $articles->hasPages(),
+        ]);
+    }
+
+    /**
+     * 記事詳細画面のレスポンス生成
+     *
+     * @param  Article  $article  記事データ（投稿者情報含む）
+     */
+    public function show(Article $article): View
+    {
+        return view('articles.show', [
+            'article' => $article,
+            'author' => $article->user,
         ]);
     }
 }

--- a/app/UseCases/Article/ShowArticleUseCase.php
+++ b/app/UseCases/Article/ShowArticleUseCase.php
@@ -20,6 +20,7 @@ final readonly class ShowArticleUseCase
      * 記事詳細を取得
      *
      * @param  int  $id  記事ID
+     *
      * @throws ModelNotFoundException 記事が見つからない、または非公開の場合
      */
     public function execute(int $id): Article
@@ -37,4 +38,4 @@ final readonly class ShowArticleUseCase
 
         return $article;
     }
-} 
+}

--- a/app/UseCases/Article/ShowArticleUseCase.php
+++ b/app/UseCases/Article/ShowArticleUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\UseCases\Article;
+
+use App\Models\Article;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+/**
+ * 記事詳細取得UseCase
+ *
+ * ビジネスロジック:
+ * - 指定されたIDの記事を取得
+ * - 公開済み記事のみ表示可能
+ * - 存在しない記事や下書き記事へのアクセスで404エラー
+ * - 投稿者情報も併せて取得（N+1問題の解決）
+ */
+final readonly class ShowArticleUseCase
+{
+    /**
+     * 記事詳細を取得
+     *
+     * @param  int  $id  記事ID
+     * @throws ModelNotFoundException 記事が見つからない、または非公開の場合
+     */
+    public function execute(int $id): Article
+    {
+        // 公開済み記事のみを対象に検索し、投稿者情報も併せて取得
+        $article = Article::query()
+            ->published()           // 公開済み記事のみ
+            ->with('user:id,name')  // N+1問題対策：ユーザー情報を事前読み込み
+            ->find($id);
+
+        // 記事が見つからない場合は404エラー
+        if ($article === null) {
+            abort(404, '記事が見つかりません');
+        }
+
+        return $article;
+    }
+} 

--- a/resources/views/articles/index.blade.php
+++ b/resources/views/articles/index.blade.php
@@ -36,10 +36,11 @@
                     </div>
                     
                     <footer class="mt-4">
-                        <span class="inline-flex items-center text-gray-400 cursor-not-allowed" title="詳細ページは未実装">
+                        <a href="{{ route('articles.show', $article->id) }}" 
+                           class="inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors">
                             続きを読む
                             <i class="fas fa-arrow-right ml-1"></i>
-                        </span>
+                        </a>
                     </footer>
                 </article>
             @endforeach

--- a/resources/views/articles/show.blade.php
+++ b/resources/views/articles/show.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', ' - 記事詳細')
+@section('title', ($article->title ?? '記事詳細') . ' - ADR Blog Lite')
 
 @section('content')
 <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -31,8 +31,7 @@
         </div>
         
         <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-4 leading-tight">
-            {{-- {{ $article->title ?? 'サンプル記事: ADRパターンの実装について' }} --}}
-            サンプル記事: ADRパターンの実装について
+            {{ $article->title }}
         </h1>
         
         <div class="flex items-center justify-between flex-wrap gap-4">
@@ -44,32 +43,22 @@
                 </div>
                 <div class="ml-3">
                     <p class="text-sm font-medium text-gray-900 dark:text-white">
-                        {{-- {{ $article->author ?? '著者名' }} --}}
-                        著者名
+                        {{ $author->name }}
                     </p>
                     <p class="text-sm text-gray-500 dark:text-gray-400">
-                        {{-- {{ $article->created_at->format('Y年m月d日') ?? now()->format('Y年m月d日') }} --}}
-                        {{ now()->format('Y年m月d日') }}
+                        {{ $article->created_at->format('Y年m月d日') }}
                     </p>
                 </div>
             </div>
             
-            <!-- Action Buttons -->
+            <!-- 公開中の記事ラベル -->
             <div class="flex items-center space-x-3">
-                <a href="{{ route('articles.edit', ['article' => 1]) ?? '/articles/1/edit' }}" 
-                   class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
-                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                <span class="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                    <svg class="w-3 h-3 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
                     </svg>
-                    編集
-                </a>
-                <button type="button" 
-                        class="inline-flex items-center px-3 py-2 text-sm font-medium text-red-700 dark:text-red-400 bg-white dark:bg-gray-800 border border-red-300 dark:border-red-600 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors">
-                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
-                    </svg>
-                    削除
-                </button>
+                    公開中
+                </span>
             </div>
         </div>
     </header>
@@ -77,40 +66,7 @@
     <!-- Article Content -->
     <article class="prose prose-lg dark:prose-invert max-w-none">
         <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-8">
-            {{-- {!! $article->content ?? $sampleContent !!} --}}
-            <p class="text-lg text-gray-700 dark:text-gray-300 mb-6">
-                Action-Domain-Responder（ADR）パターンは、Webアプリケーションの設計パターンの一つで、従来のMVCパターンの問題点を解決するために提案されました。
-            </p>
-            
-            <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4 mt-8">ADRパターンとは</h2>
-            <p class="text-gray-700 dark:text-gray-300 mb-4">
-                ADRパターンは以下の3つの層で構成されます：
-            </p>
-            
-            <ul class="list-disc list-inside text-gray-700 dark:text-gray-300 mb-6 space-y-2">
-                <li><strong>Action</strong>: リクエストを受け取り、Domainへの処理を委譲する</li>
-                <li><strong>Domain</strong>: ビジネスロジックを含む核となる処理</li>
-                <li><strong>Responder</strong>: レスポンス生成の責務を担う</li>
-            </ul>
-            
-            <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-4 mt-8">実装例</h2>
-            <p class="text-gray-700 dark:text-gray-300 mb-4">
-                以下は、Laravelでの基本的なADRパターンの実装例です：
-            </p>
-            
-            <pre class="bg-gray-100 dark:bg-gray-900 p-4 rounded-lg overflow-x-auto text-sm"><code class="language-php">// Action
-class ListArticlesAction
-{
-    public function __invoke(Request $request, ListArticlesUseCase $useCase, ArticleListResponder $responder)
-    {
-        $articles = $useCase->execute();
-        return $responder->respond($articles);
-    }
-}</code></pre>
-            
-            <p class="text-gray-700 dark:text-gray-300 mt-6">
-                このように、各層の責務を明確に分離することで、保守性の高いコードを実現できます。
-            </p>
+            <div class="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">{{ $article->content }}</div>
         </div>
     </article>
 
@@ -125,13 +81,12 @@ class ListArticlesAction
                 記事一覧に戻る
             </a>
             
-            <a href="{{ route('articles.create', []) ?? '/articles/create' }}" 
-               class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors">
-                新しい記事を作成
+            <span class="inline-flex items-center px-4 py-2 text-sm font-medium text-gray-500 bg-gray-100 rounded-md cursor-not-allowed">
+                新しい記事を作成（未実装）
                 <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v3m0 0v3m0-3h3m-3 0H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                 </svg>
-            </a>
+            </span>
         </div>
     </nav>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Actions\Article\ListArticlesAction;
+use App\Actions\Article\ShowArticleAction;
 use Illuminate\Support\Facades\Route;
 
 // ホームページ
@@ -10,3 +11,8 @@ Route::get('/', function () {
 
 // 記事一覧表示（ADRパターン）
 Route::get('/articles', ListArticlesAction::class)->name('articles.index');
+
+// 記事詳細表示（ADRパターン）
+Route::get('/articles/{id}', ShowArticleAction::class)
+    ->name('articles.show')
+    ->where('id', '[0-9]+'); // 数値のみ許可

--- a/tests/Feature/ArticleDetailTest.php
+++ b/tests/Feature/ArticleDetailTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Article;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * 記事詳細機能の統合テスト
+ *
+ * ADRパターンで実装された記事詳細機能の
+ * エンドツーエンドテストを実行
+ */
+class ArticleDetailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // テスト用ユーザーを作成
+        $this->user = User::factory()->create([
+            'name' => 'テストユーザー',
+            'email' => 'test@example.com',
+        ]);
+    }
+
+    public function test_公開記事詳細ページが正常に表示される(): void
+    {
+        // 公開記事を作成
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+            'title' => 'テスト記事のタイトル',
+            'content' => 'これはテスト記事の内容です。詳細な記事の内容が表示されます。',
+        ]);
+
+        $response = $this->get("/articles/{$article->id}");
+
+        $response->assertStatus(200);
+        $response->assertViewIs('articles.show');
+        $response->assertSee($article->title);
+        $response->assertSee($article->content);
+        $response->assertSee($this->user->name);
+    }
+
+    public function test_下書き記事詳細ページにアクセスすると404エラー(): void
+    {
+        // 下書き記事を作成
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->get("/articles/{$article->id}");
+
+        $response->assertStatus(404);
+    }
+
+    public function test_存在しない記事IDでアクセスすると404エラー(): void
+    {
+        $response = $this->get('/articles/99999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_記事詳細ページに投稿者情報が表示される(): void
+    {
+        // 特定の名前のユーザーで記事を作成
+        $author = User::factory()->create(['name' => '記事投稿者']);
+        $article = Article::factory()->create([
+            'user_id' => $author->id,
+            'status' => 'published',
+        ]);
+
+        $response = $this->get("/articles/{$article->id}");
+
+        $response->assertStatus(200);
+        $response->assertSee($author->name);
+        $response->assertSee($article->created_at->format('Y年m月d日'));
+    }
+
+    public function test_記事詳細ページのパンくずリストが正常に動作する(): void
+    {
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+        ]);
+
+        $response = $this->get("/articles/{$article->id}");
+
+        $response->assertStatus(200);
+        // パンくずリストの記事一覧リンクが存在することを確認
+        $response->assertSee('記事一覧');
+        $response->assertSee(route('articles.index'));
+    }
+
+    public function test_記事詳細ページから記事一覧に戻るリンクが動作する(): void
+    {
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+        ]);
+
+        $response = $this->get("/articles/{$article->id}");
+
+        $response->assertStatus(200);
+        // 記事一覧に戻るリンクが存在することを確認
+        $response->assertSee('記事一覧に戻る');
+    }
+
+    public function test_記事一覧から詳細ページへのリンクが正常に動作する(): void
+    {
+        // 複数の公開記事を作成
+        $articles = Article::factory()->count(3)->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+        ]);
+
+        // 記事一覧ページを取得
+        $response = $this->get('/articles');
+        $response->assertStatus(200);
+
+        // 各記事の詳細リンクが存在することを確認
+        foreach ($articles as $article) {
+            $response->assertSee(route('articles.show', $article->id));
+        }
+    }
+
+    public function test_無効な記事IDフォーマットでアクセスすると404エラー(): void
+    {
+        // 非数値の記事IDでアクセス
+        $response = $this->get('/articles/invalid-id');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_負の記事IDでアクセスすると404エラー(): void
+    {
+        $response = $this->get('/articles/-1');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_複数の記事が存在する場合でも正しい記事が表示される(): void
+    {
+        // 複数の記事を作成
+        $article1 = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+            'title' => '最初の記事',
+            'content' => '最初の記事の内容です。',
+        ]);
+
+        $article2 = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+            'title' => '二番目の記事',
+            'content' => '二番目の記事の内容です。',
+        ]);
+
+        // 最初の記事の詳細を確認
+        $response1 = $this->get("/articles/{$article1->id}");
+        $response1->assertStatus(200);
+        $response1->assertSee($article1->title);
+        $response1->assertSee($article1->content);
+        $response1->assertDontSee($article2->title);
+
+        // 二番目の記事の詳細を確認
+        $response2 = $this->get("/articles/{$article2->id}");
+        $response2->assertStatus(200);
+        $response2->assertSee($article2->title);
+        $response2->assertSee($article2->content);
+        $response2->assertDontSee($article1->title);
+    }
+} 

--- a/tests/Feature/ArticleDetailTest.php
+++ b/tests/Feature/ArticleDetailTest.php
@@ -62,7 +62,7 @@ class ArticleDetailTest extends TestCase
         $response->assertStatus(404);
     }
 
-    public function test_存在しない記事IDでアクセスすると404エラー(): void
+    public function test_存在しない記事_i_dでアクセスすると404エラー(): void
     {
         $response = $this->get('/articles/99999');
 
@@ -132,7 +132,7 @@ class ArticleDetailTest extends TestCase
         }
     }
 
-    public function test_無効な記事IDフォーマットでアクセスすると404エラー(): void
+    public function test_無効な記事_i_dフォーマットでアクセスすると404エラー(): void
     {
         // 非数値の記事IDでアクセス
         $response = $this->get('/articles/invalid-id');
@@ -140,7 +140,7 @@ class ArticleDetailTest extends TestCase
         $response->assertStatus(404);
     }
 
-    public function test_負の記事IDでアクセスすると404エラー(): void
+    public function test_負の記事_i_dでアクセスすると404エラー(): void
     {
         $response = $this->get('/articles/-1');
 
@@ -178,4 +178,4 @@ class ArticleDetailTest extends TestCase
         $response2->assertSee($article2->content);
         $response2->assertDontSee($article1->title);
     }
-} 
+}

--- a/tests/Unit/Actions/Article/ShowArticleActionTest.php
+++ b/tests/Unit/Actions/Article/ShowArticleActionTest.php
@@ -81,7 +81,7 @@ class ShowArticleActionTest extends TestCase
         $this->action->__invoke($request, $article->id);
     }
 
-    public function test_存在しない記事IDでアクセスすると404エラー(): void
+    public function test_存在しない記事_i_dでアクセスすると404エラー(): void
     {
         $nonExistentId = 99999;
         $request = Request::create("/articles/{$nonExistentId}", 'GET');
@@ -90,7 +90,7 @@ class ShowArticleActionTest extends TestCase
         $this->action->__invoke($request, $nonExistentId);
     }
 
-    public function test_負の記事IDでアクセスすると404エラー(): void
+    public function test_負の記事_i_dでアクセスすると404エラー(): void
     {
         $invalidId = -1;
         $request = Request::create("/articles/{$invalidId}", 'GET');
@@ -99,7 +99,7 @@ class ShowArticleActionTest extends TestCase
         $this->action->__invoke($request, $invalidId);
     }
 
-    public function test_ゼロの記事IDでアクセスすると404エラー(): void
+    public function test_ゼロの記事_i_dでアクセスすると404エラー(): void
     {
         $invalidId = 0;
         $request = Request::create("/articles/{$invalidId}", 'GET');
@@ -124,4 +124,4 @@ class ShowArticleActionTest extends TestCase
         $this->assertEquals('特定の投稿者', $data['author']->name);
         $this->assertEquals($specificUser->id, $data['author']->id);
     }
-} 
+}

--- a/tests/Unit/Actions/Article/ShowArticleActionTest.php
+++ b/tests/Unit/Actions/Article/ShowArticleActionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Unit\Actions\Article;
+
+use App\Actions\Article\ShowArticleAction;
+use App\Models\Article;
+use App\Models\User;
+use App\Responders\Web\ArticleWebResponder;
+use App\UseCases\Article\ShowArticleUseCase;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * ShowArticleActionのユニットテスト
+ *
+ * ADRパターンのエントリポイントのテスト:
+ * - HTTPリクエストとパラメータの受け取り
+ * - パラメータの検証と抽出
+ * - UseCaseへの委譲
+ * - Responderでのレスポンス生成
+ *
+ * 注意: readonly finalクラスはモックできないため、
+ * 実際のオブジェクトを使用した統合テスト形式で実装
+ */
+class ShowArticleActionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ShowArticleAction $action;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $useCase = new ShowArticleUseCase;
+        $responder = new ArticleWebResponder;
+        $this->action = new ShowArticleAction($useCase, $responder);
+
+        // テスト用ユーザー作成
+        $this->user = User::factory()->create();
+    }
+
+    public function test_公開済み記事を正常に表示する(): void
+    {
+        // 公開済み記事を作成
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'published',
+            'title' => 'テスト記事タイトル',
+            'content' => 'テスト記事の内容です。',
+        ]);
+
+        $request = Request::create("/articles/{$article->id}", 'GET');
+        $result = $this->action->__invoke($request, $article->id);
+
+        $this->assertInstanceOf(View::class, $result);
+        $this->assertEquals('articles.show', $result->getName());
+
+        // ビューデータを確認
+        $data = $result->getData();
+        $this->assertEquals($article->id, $data['article']->id);
+        $this->assertEquals($article->title, $data['article']->title);
+        $this->assertEquals($this->user->name, $data['author']->name);
+    }
+
+    public function test_下書き記事にアクセスすると404エラー(): void
+    {
+        // 下書き記事を作成
+        $article = Article::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'draft',
+        ]);
+
+        $request = Request::create("/articles/{$article->id}", 'GET');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->action->__invoke($request, $article->id);
+    }
+
+    public function test_存在しない記事IDでアクセスすると404エラー(): void
+    {
+        $nonExistentId = 99999;
+        $request = Request::create("/articles/{$nonExistentId}", 'GET');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->action->__invoke($request, $nonExistentId);
+    }
+
+    public function test_負の記事IDでアクセスすると404エラー(): void
+    {
+        $invalidId = -1;
+        $request = Request::create("/articles/{$invalidId}", 'GET');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->action->__invoke($request, $invalidId);
+    }
+
+    public function test_ゼロの記事IDでアクセスすると404エラー(): void
+    {
+        $invalidId = 0;
+        $request = Request::create("/articles/{$invalidId}", 'GET');
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->action->__invoke($request, $invalidId);
+    }
+
+    public function test_投稿者情報が正しく取得される(): void
+    {
+        // 特定の名前のユーザーで記事を作成
+        $specificUser = User::factory()->create(['name' => '特定の投稿者']);
+        $article = Article::factory()->create([
+            'user_id' => $specificUser->id,
+            'status' => 'published',
+        ]);
+
+        $request = Request::create("/articles/{$article->id}", 'GET');
+        $result = $this->action->__invoke($request, $article->id);
+
+        $data = $result->getData();
+        $this->assertEquals('特定の投稿者', $data['author']->name);
+        $this->assertEquals($specificUser->id, $data['author']->id);
+    }
+} 


### PR DESCRIPTION
## 🎯 概要

GitHub issue #6に対応した記事詳細表示機能をADRパターンで実装しました。

## 📋 実装内容

### ADR層実装
- ✅ `ShowArticleAction` - パラメータバリデーションとHTTPリクエスト処理
- ✅ `ShowArticleUseCase` - 記事取得ロジックとビジネスルール適用  
- ✅ `ArticleWebResponder` - 詳細表示対応のレスポンス整形

### 機能実装
- ✅ `/articles/{id}` ルートでの記事詳細表示
- ✅ 公開済み記事のみ表示可能
- ✅ 存在しない記事や下書き記事で404エラー
- ✅ 投稿者情報の表示
- ✅ 記事一覧からの詳細リンク

### ファイル変更
- `app/Actions/Article/ShowArticleAction.php` - 新規作成
- `app/UseCases/Article/ShowArticleUseCase.php` - 新規作成
- `app/Responders/Web/ArticleWebResponder.php` - show()メソッド追加
- `routes/web.php` - 記事詳細ルート追加
- `resources/views/articles/show.blade.php` - 動的データ表示対応
- `resources/views/articles/index.blade.php` - 詳細リンク追加

## 🧪 テスト実装

### 単体テスト
- `tests/Unit/Actions/Article/ShowArticleActionTest.php` - 6個のテストケース
  - 公開記事の正常表示
  - 下書き記事での404エラー
  - 存在しない記事での404エラー
  - 無効なIDでの404エラー
  - 投稿者情報の取得確認

### 統合テスト  
- `tests/Feature/ArticleDetailTest.php` - 10個の統合テストケース
  - エンドツーエンドのHTTPテスト
  - ビューの正常表示確認
  - ナビゲーションリンクの動作確認

## ✅ テスト結果

**全テスト実行**: 47個のテスト / 145個のアサーション **すべて成功** ✅

```bash
PHPUnit 11.5.24 by Sebastian Bergmann and contributors.
...............................................   47 / 47 (100%)
Time: 00:01.193, Memory: 46.50 MB
OK (47 tests, 145 assertions)
```

## 🎓 ADR学習ポイント

### Action層
- URLパラメータの検証と抽出
- 適切なエラーハンドリング（404エラー）
- UseCaseへの適切な委譲

### UseCase層  
- ビジネスロジックの実装
- 公開記事のみ取得するフィルタリング
- N+1問題対策（eager loading）

### Responder層
- レスポンス形式の統一
- ビューデータの適切な整形
- エラーケースの処理

## 🔧 動作確認

- ブラウザでの動作確認済み ✅
- 記事一覧から詳細への遷移 ✅  
- 404エラーページの表示 ✅
- 投稿者情報の正常表示 ✅

## 📚 参考

- [GitHub Issue #6](https://github.com/nakajima97/adr-blog-lite/issues/6)
- [ADRアーキテクチャ設計書](../docs/architecture.md)
- [開発手順書](../docs/development-guide.md)

Closes #6